### PR TITLE
unblob TestPlan to get back the json objects of nsd and td

### DIFF
--- a/src/main/groovy/com/github/tng/vnv/planner/WorkflowManager.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/WorkflowManager.groovy
@@ -60,7 +60,7 @@ class WorkflowManager {
     void searchForScheduledPlan() {
         pendingTestPlan = testPlanService.findPendingTestPlan()
         if (pendingTestPlan == null) {
-            TestPlan nextTestPlan = testPlanService.findNextScheduledTestPlan()
+            TestPlan nextTestPlan = testPlanService.findNextScheduledTestPlan().unBlob()
             if (nextTestPlan != null) {
                 log.info("No Pending plan. Available scheduled Plan Descr: [\"" + nextTestPlan.description + "\"]")
                 TestPlanResponse testPlanResponse = curator.proceedWith(nextTestPlan)


### PR DESCRIPTION
while trying to resolve Planner null descriptors to Curator according to https://github.com/sonata-nfv/tng-vnv-planner/issues/42