### PR TITLE
TestPlans Status Exeptions for Planner intenally and list testPlans externally

### DIFF
--- a/src/main/groovy/com/github/tng/vnv/planner/client/Curator.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/client/Curator.groovy
@@ -58,20 +58,28 @@ class Curator {
     @Qualifier('restTemplateWithAuth')
     RestTemplate restTemplate
 
-    @Value('${app.curator.test.plan.curate.endpoint}')
-    def testPlanCurateEndpoint
-    @Value('${app.curator.cancel.test.plan.curate.endpoint}')
-    def cancelTestPlanCurateEndpoint
+    @Value('${app.curator.test.plan.prepare.endpoint}')
+    def testPlanPrepareEndpoint
+    @Value('${app.curator.test.plan.cancel.endpoint}')
+    def testPlanCancellationEndpoint
+    @Value('${app.curator.test.plan.ping.endpoint}')
+    def testPlanPingEndpoint
 
+
+
+    void ping() {
+        callExternalEndpoint(restTemplate.get(testPlanPingEndpoint),
+                'Curator.ping(TestPlan)',testPlanPingEndpoint)
+    }
 
     TestPlanResponse proceedWith(TestPlan testPlan) {
         def createRequest = new TestPlanRequest(nsd: testPlan.nsd, testd: testPlan.testd, lastTest: false)
-        callExternalEndpoint(restTemplate.postForEntity(testPlanCurateEndpoint, createRequest, TestPlanResponse),
-                'Curator.proceedWith(TestPlan)',testPlanCurateEndpoint).body
+        callExternalEndpoint(restTemplate.postForEntity(testPlanPrepareEndpoint, createRequest, TestPlanResponse),
+                'Curator.proceedWith(TestPlan)',testPlanPrepareEndpoint).body
     }
     void deleteTestPlan(uuid) {
-        callExternalEndpoint(restTemplate.delete(cancelTestPlanCurateEndpoint, uuid),
-                'Curator.deleteTestPlan(TestPlan)',cancelTestPlanCurateEndpoint)
+        callExternalEndpoint(restTemplate.delete(testPlanCancellationEndpoint, uuid),
+                'Curator.deleteTestPlan(TestPlan)',testPlanCancellationEndpoint)
     }
 
     TestPlan update(def testPlan) {

--- a/src/main/groovy/com/github/tng/vnv/planner/controller/TestPlanController.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/controller/TestPlanController.groovy
@@ -59,6 +59,12 @@ class TestPlanController {
     @Autowired
     TestPlanService testPlanService
 
+    @GetMapping('/{testPlanListUuid}')
+    @ResponseBody
+    TestSuite listByTestSuite(@PathVariable('testPlanListUuid') String uuid) {
+        testPlanService.findByTestSuite(uuid)
+    }
+
     @ApiResponses(value = [@ApiResponse(code = 400, message = 'Bad Request')])
     @PostMapping('')
     @ResponseBody

--- a/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
@@ -124,7 +124,21 @@ class TestPlanRequest {
 @EqualsAndHashCode
 class TestPlanResponse {
     String uuid
+    @ApiModelProperty(
+            value = 'Test Plan Status',
+            allowEmptyValue = false,
+            example = 'STARTING, COMPLETED, CANCELLING, CANCELLED, ERROR',
+            required = true)
+    @NotNull
     String status
+
+    @ApiModelProperty(
+            value = 'Test Plan Exception message',
+            allowEmptyValue = false,
+            example = 'run time exception')
+    @NotNull
+    String exception
+
 }
 
 class TestPlanCallback {

--- a/src/main/groovy/com/github/tng/vnv/planner/repository/TestSuiteRepository.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/repository/TestSuiteRepository.groovy
@@ -40,5 +40,6 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface TestSuiteRepository extends JpaRepository<TestSuite, Long> {
+    TestSuite findById(Long id);
 
 }

--- a/src/main/groovy/com/github/tng/vnv/planner/service/TestPlanService.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/service/TestPlanService.groovy
@@ -42,6 +42,7 @@ import com.github.tng.vnv.planner.repository.TestPlanRepository
 import com.github.tng.vnv.planner.repository.TestPlanRestRepository
 import com.github.tng.vnv.planner.model.NetworkServiceDescriptor
 import com.github.tng.vnv.planner.model.TestPlan
+import com.github.tng.vnv.planner.repository.TestSuiteRepository
 import com.github.tng.vnv.planner.utils.TEST_PLAN_STATUS
 import groovy.util.logging.Log
 import org.springframework.beans.factory.annotation.Autowired
@@ -55,6 +56,8 @@ class TestPlanService {
 
     @Autowired
     TestPlanRepository testPlanRepository
+    @Autowired
+    TestSuiteRepository testSuiteRepository
     @Autowired
     TestPlanRestRepository testPlanRestRepository
 
@@ -141,8 +144,13 @@ class TestPlanService {
     TestPlan findNextScheduledTestPlan() {
         testPlanRepository.findFirstByStatus(TEST_PLAN_STATUS.SCHEDULED)
     }
+
     TestPlan findPendingTestPlan() {
         testPlanRepository.findFirstByStatus(TEST_PLAN_STATUS.PENDING)
+    }
+
+    List<TestPlan> findByTestSuite(Log uuid) {
+        testSuiteRepository.findById(uuid)?.testPlans
     }
 }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/service/TestSuiteService.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/service/TestSuiteService.groovy
@@ -50,9 +50,6 @@ class TestSuiteService {
     @Autowired
     TestSuiteRepository testSuiteRepository
 
-    TestSuite getOne(Long id){
-        testSuiteRepository.getOne(id)
-    }
     TestSuite save(TestSuite testSuite){
         testSuiteRepository.save(testSuite)
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,8 +76,9 @@ app:
   curator:
     host: tng-vnv-curator
     base.url: http://${app.curator.host}:6200/api/v1
-    test.plan.curate.endpoint: ${app.curator.base.url}/test-preparations
-    cancel.test.plan.curate.endpoint: ${app.curator.base.url}/test-preparations/{uuid}
+    test.plan.ping.endpoint: ${app.curator.base.url}/ping
+    test.plan.prepare.endpoint: ${app.curator.base.url}/test-preparations
+    test.plan.cancel.endpoint: ${app.curator.base.url}/test-preparations/{uuid}
 
   queue.capacity: 500
   pool:

--- a/src/main/resources/static/swagger-dependencies.json
+++ b/src/main/resources/static/swagger-dependencies.json
@@ -774,9 +774,21 @@
         },
         "TestPlanResponse": {
             "type": "object",
+            "required": [
+                "status"
+            ],
             "properties": {
+                "exception": {
+                    "type": "string",
+                    "example": "run time exception",
+                    "description": "Test Plan Exception message",
+                    "allowEmptyValue": false
+                },
                 "status": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "STARTING, COMPLETED, CANCELLING, CANCELLED, ERROR",
+                    "description": "Test Plan Status",
+                    "allowEmptyValue": false
                 },
                 "uuid": {
                     "type": "string"

--- a/src/main/resources/static/swagger.json
+++ b/src/main/resources/static/swagger.json
@@ -366,6 +366,44 @@
                 }
             }
         },
+        "/api/v1/test-plans/{testPlanListUuid}": {
+            "get": {
+                "tags": [
+                    "test-plan-controller"
+                ],
+                "summary": "listByTestSuite",
+                "operationId": "listByTestSuiteUsingGET",
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "name": "testPlanListUuid",
+                        "in": "path",
+                        "description": "testPlanListUuid",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/TestSuite"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    }
+                }
+            }
+        },
         "/api/v1/test-plans/{uuid}": {
             "put": {
                 "tags": [


### PR DESCRIPTION
resolving issues: 
- Client can GET the testPlans status https://github.com/sonata-nfv/tng-vnv-planner/issues/46
- Curator will response to the initial Planner request with an status and a exception in case of an error status https://github.com/sonata-nfv/tng-vnv-planner/issues/39
- Each TestPlan returned to the callback of Planner might contain more than one testResult's https://github.com/sonata-nfv/tng-vnv-planner/issues/38 
- After the end of all testPlans, Curator will send a callback to Planner with all testPlan execution results https://github.com/sonata-nfv/tng-vnv-planner/issues/36