### PR TITLE
e2e-integration with test H2 db

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -38,6 +38,6 @@ ENV DATABASE_NAME planner
 ENV DATABASE_USER sonatatest
 ENV DATABASE_PASSWORD sonata
 ENV DATABASE_PORT 5432
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=docker", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=test", "/app.jar"]
 EXPOSE 6100
 ADD /libs/${name}-${version}.jar /app.jar

--- a/src/main/groovy/com/github/tng/vnv/planner/WorkflowManager.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/WorkflowManager.groovy
@@ -58,6 +58,7 @@ class WorkflowManager {
 
     @Scheduled(fixedRate = 5000L , initialDelay = 1000L)
     void searchForScheduledPlan() {
+        log.info("#~#vnvlogPlanner.WorkflowManager.searchForScheduledPlan")
         pendingTestPlan = testPlanService.findPendingTestPlan()
         if (pendingTestPlan == null) {
             TestPlan nextTestPlan = testPlanService.findNextScheduledTestPlan()?.unBlob()

--- a/src/main/groovy/com/github/tng/vnv/planner/controller/CatalogueCallbackController.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/controller/CatalogueCallbackController.groovy
@@ -79,7 +79,7 @@ class CatalogueCallbackController {
     @PostMapping('/on-change')
     @ResponseBody
     TestSuite onChange(@Valid @RequestBody PackageCallback body) {
-        log.info("##vnvlog Executor.executeTests request. ")
+        log.info("#~#vnvlogPlanner.CatalogueCallbackController.onChange: PackageId: ${body?.packageId} STR [PackageCallback: ${body}]")
         TestSuite testSuite = new TestSuite();
         switch (body.eventName) {
             case PACKAGE_DELETED:
@@ -89,6 +89,7 @@ class CatalogueCallbackController {
             default:
                testSuite = scheduler.create(new Package(packageId: body.packageId))
         }
+        log.info("#~#vnvlogPlanner.CatalogueCallbackController.onChange: PackageId: ${body?.packageId} END [PackageCallback: ${body}]")
         testSuite
     }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackController.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackController.groovy
@@ -65,7 +65,9 @@ class CuratorCallbackController {
     @PostMapping('/on-change/completed')
     @ResponseBody
     void onChangeCompleted(@Valid @RequestBody TestPlanCallback callback) {
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChangeCompleted: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} STR [CallbackBody.status: ${callback.status}]")
         testPlanService.update(callback.testPlanUuid, callback.status)
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChangeCompleted: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} END [CallbackBody.status: ${callback.status}]")
     }
 
     @ApiResponses(value = [
@@ -75,7 +77,9 @@ class CuratorCallbackController {
     @PostMapping('/on-change/')
     @ResponseBody
     void onChange(@Valid @RequestBody TestPlanCallback callback) {
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChange: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} STR [CallbackBody.status: ${callback.status}]")
         testPlanService.update(callback.testPlanUuid, callback.status)
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChange: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} END [CallbackBody.status: ${callback.status}]")
     }
 }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/controller/TestPlanController.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/controller/TestPlanController.groovy
@@ -41,6 +41,7 @@ import com.github.tng.vnv.planner.model.TestDescriptor
 import com.github.tng.vnv.planner.model.TestPlan
 import com.github.tng.vnv.planner.model.TestSuite
 import com.github.tng.vnv.planner.service.TestPlanService
+import groovy.util.logging.Log
 import io.swagger.annotations.ApiResponse
 import io.swagger.annotations.ApiResponses
 import org.springframework.beans.factory.annotation.Autowired
@@ -48,6 +49,7 @@ import org.springframework.web.bind.annotation.*
 
 import javax.validation.Valid
 
+@Log
 @RestController
 @RequestMapping('/api/v1/test-plans')
 class TestPlanController {
@@ -69,20 +71,26 @@ class TestPlanController {
     @PostMapping('')
     @ResponseBody
     TestSuite save(@Valid @RequestBody TestSuite testSuite) {
+        log.info("#~#vnvlogPlanner.TestPlanController.save: TestSuite.uuid: ${testSuite?.uuid} STR [PackageCallback: ${testSuite}]")
         scheduler.create(testSuite)
+        log.info("#~#vnvlogPlanner.TestPlanController.save: TestSuite.uuid: ${testSuite?.uuid} END [PackageCallback: ${testSuite}]")
     }
 
     @ApiResponses(value = [@ApiResponse(code = 400, message = 'Bad Request')])
     @PutMapping('{uuid}')
     @ResponseBody
     TestSuite update(@Valid @RequestBody TestSuite testSuite) {
+        log.info("#~#vnvlogPlanner.TestPlanController.update: TestSuite.uuid: ${testSuite?.uuid} STR [PackageCallback: ${testSuite}]")
         scheduler.update(testSuite)
+        log.info("#~#vnvlogPlanner.TestPlanController.update: TestSuite.uuid: ${testSuite?.uuid} END [PackageCallback: ${testSuite}]")
     }
 
     @DeleteMapping('{uuid}')
     @ResponseBody
     void deleteTestPlan(@PathVariable String uuid) {
+        log.info("#~#vnvlogPlanner.TestPlanController.deleteTestPlan: TestSuite.uuid: $uuid STR")
         manager.deleteTestPlan(uuid)
+        log.info("#~#vnvlogPlanner.TestPlanController.deleteTestPlan: TestSuite.uuid: $uuid END")
     }
 
     @ApiResponses(value = [@ApiResponse(code = 400, message = 'Bad Request')])

--- a/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
@@ -197,7 +197,7 @@ class TestPlanCallback {
 
     @ApiModelProperty(
             value = 'Test Plan Result List',
-            allowEmptyValue = false)
+            allowEmptyValue = true)
     List<TestResult> testResults
 
     @ApiModelProperty(

--- a/src/main/groovy/com/github/tng/vnv/planner/service/TestPlanService.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/service/TestPlanService.groovy
@@ -117,15 +117,20 @@ class TestPlanService {
 
     TestPlan save(TestPlan testPlan){
         testPlan.uuid = testPlan.uuid?:UUID.randomUUID().toString()
+        log.info("#~#vnvlogPlanner.TestPlanService.save: testPlan.uuid: ${testPlan?.uuid} STR [status: ${testPlan?.status} ]")
         testPlanRepository.save(testPlan.blob())
         testPlanRestRepository.create(testPlan)
+        log.info("#~#vnvlogPlanner.TestPlanService.save: testPlan.uuid: ${testPlan?.uuid} END [status: ${testPlan?.status} ]")
+        testPlan
     }
 
     TestPlan update(String uuid, String status) {
+        log.info("#~#vnvlogPlanner.TestPlanService.update: testPlan uuid: $uuid STR [status: ${status} ]")
         TestPlan testPlan = findByUuid(uuid)
         testPlan.status = status
         testPlanRepository.save(testPlan)
         testPlanRestRepository.update(testPlan)
+        log.info("#~#vnvlogPlanner.TestPlanService.update: testPlan uuid: $uuid END [status: ${status} ]")
         testPlan
     }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/utils/DebugHelper.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/utils/DebugHelper.groovy
@@ -7,9 +7,9 @@ import org.springframework.http.ResponseEntity
 class DebugHelper {
     static def callExternalEndpoint(ResponseEntity responseEntity, def methodName, def endpoint, String message="ERROR CONNECTING WITH ENDPOINT"){
         if(responseEntity?.statusCodeValue in [200, 201, 202, 203, 204, 205, 206, 207, 208, 226]) {
-            log.info("##vnvlog-v.2:$methodName call_endpoint: $endpoint, status: ${responseEntity.statusCode}")
+            log.info("##vnvlogPlanner-v.3:$methodName call_endpoint: $endpoint, status: ${responseEntity.statusCode}")
         } else {
-            log.severe("##vnvlog-v.2:$methodName $message: $endpoint, status: ${responseEntity?.statusCode?:'no response'}")
+            log.severe("##vnvlogPlanner-v.3:$methodName $message: $endpoint, status: ${responseEntity?.statusCode?:'no response'}")
             return null
         }
         responseEntity

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,7 +108,7 @@ spring:
     validationQuery: SELECT 1
     platform: postgres
   jpa:
-    hibernate.ddl-auto: validate
+    hibernate.ddl-auto: none
     show-sql: false
     database: postgresql
     database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -129,8 +129,8 @@ spring:
     validationQuery: SELECT 1
     platform: postgres
   jpa:
-#    hibernate.ddl-auto: none
-    hibernate.ddl-auto: validate
+    hibernate.ddl-auto: none
+#    hibernate.ddl-auto: validate
     show-sql: false
     database: postgresql
     database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -2,6 +2,9 @@
 
 create sequence hibernate_sequence;
 
+--alter sequence hibernate_sequence
+--     owner to sonatatest;
+
 create table if not exists test_suite
 (
     id   bigint not null

--- a/src/main/resources/static/swagger-dependencies.json
+++ b/src/main/resources/static/swagger-dependencies.json
@@ -738,7 +738,7 @@
                 "test_results": {
                     "type": "array",
                     "description": "Test Plan Result List",
-                    "allowEmptyValue": false,
+                    "allowEmptyValue": true,
                     "items": {
                         "$ref": "#/definitions/TestResult"
                     }

--- a/src/main/resources/static/swagger.json
+++ b/src/main/resources/static/swagger.json
@@ -674,7 +674,7 @@
                 "test_results": {
                     "type": "array",
                     "description": "Test Plan Result List",
-                    "allowEmptyValue": false,
+                    "allowEmptyValue": true,
                     "items": {
                         "$ref": "#/definitions/TestResult"
                     }

--- a/src/test/groovy/com/github/tng/vnv/planner/WorkFlowManagerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/WorkFlowManagerTest.groovy
@@ -73,7 +73,13 @@ class WorkFlowManagerTest extends TestRestSpec {
                         event_actor: 'tng-vnv-curator',
                         status: 'COMPLETED',
                         test_plan_uuid: TEST_PLAN_UUID_3,
-                        test_results_uuid: TEST_RESULT_UUID,
+                        test_results: [
+                                            [
+                                                test_uuid: TEST_RESULT_UUID,
+                                                test_result_uuid: '45678',
+                                                status: TEST_PLAN_STATUS.COMPLETED,
+                                            ],
+                                ],
                         test_plan_repository: 'tng-rep',
                         test_results_repository: 'tng-res',
                 ]

--- a/src/test/resources/static/json/testPlanPayload.json
+++ b/src/test/resources/static/json/testPlanPayload.json
@@ -684,6 +684,326 @@
         "version": "0.1"
       },
       "uuid": "17898765456"
+    },
+    {
+      "description": "Test Plan Description: Adhoc TD,NSD request for testing",
+      "id": 5,
+      "index": 3,
+      "nsd": {
+        "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/service-descriptor/nsd-schema.yml",
+        "vendor": "eu.sonata-nfv",
+        "name": "mediapilot-service",
+        "version": "0.2",
+        "author": "Ignacio Dominguez @: atos",
+        "description": "This NS provides the video streaming service for the immersive media pilot. [integrationtests at 18:28utc 2019/04/16]",
+        "network_functions": [
+          {
+            "vnf_id": "vnf-ma",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-ma",
+            "vnf_version": "0.2"
+          },
+          {
+            "vnf_id": "vnf-mse",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-mse",
+            "vnf_version": "0.2"
+          },
+          {
+            "vnf_id": "vnf-cms",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-cms",
+            "vnf_version": "0.1"
+          }
+        ],
+        "connection_points": [
+          {
+            "id": "nscpexternal",
+            "interface": "ipv4",
+            "type": "external"
+          }
+        ],
+        "testing_tags": [
+          "packetLossTest"
+        ],
+        "virtual_links": [
+          {
+            "id": "vlexternal",
+            "connectivity_type": "E-LAN",
+            "connection_points_reference": [
+              "vnf-ma:rtmp",
+              "vnf-mse:hls",
+              "vnf-cms:api",
+              "nscpexternal"
+            ]
+          },
+          {
+            "id": "cms-aggregator",
+            "connectivity_type": "E-Line",
+            "connection_points_reference": [
+              "vnf-cms:api",
+              "vnf-ma:api"
+            ]
+          },
+          {
+            "id": "aggregator-mse",
+            "connectivity_type": "E-Line",
+            "connection_points_reference": [
+              "vnf-ma:rtmp",
+              "vnf-mse:rtmp"
+            ]
+          }
+        ]
+      },
+      "status": "string",
+      "testd": {
+        "author": "Ignacio Dominguez, Felipe Vicens (ATOS)",
+        "description": "Performance test for video analysis",
+        "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/test-descriptor/testdescriptor-schema.yml",
+        "name": "test-immersive-media",
+        "phases": [
+          {
+            "id": "setup",
+            "steps": [
+              {
+                "action": "deploy",
+                "description": "Deploying a NS",
+                "name": "deployment"
+              },
+              {
+                "action": "configure",
+                "description": "Configuration",
+                "name": "configuration",
+                "probes": [
+                  {
+                    "description": "A service initial configuration container",
+                    "id": "initiator",
+                    "image": "ignaciodomin/media-initiator:dev",
+                    "name": "initiator",
+                    "parameters": [
+                      {
+                        "key": "CAMERA",
+                        "value": "test"
+                      },
+                      {
+                        "key": "CMS",
+                        "value": "$(vnf-cms/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "MA",
+                        "value": "$(vnf-ma/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "MSE",
+                        "value": "$(vnf-mse/endpoints/id:floating_ip/address)"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Ffprobe",
+                    "id": "ffprobe",
+                    "image": "ignaciodomin/media-ffprobe:dev",
+                    "name": "ffprobe",
+                    "parameters": [
+                      {
+                        "key": "STREAMING_ENGINE",
+                        "value": "$(vnf-mse/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "plane"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Parser",
+                    "id": "parser",
+                    "image": "ignaciodomin/media-parser:dev",
+                    "name": "parser",
+                    "parameters": []
+                  },
+                  {
+                    "description": "Content Producer Emulator (CPE) To generate a RTMP flow",
+                    "id": "cpe",
+                    "image": "ignaciodomin/media-cpe:plane",
+                    "name": "cpe",
+                    "parameters": [
+                      {
+                        "key": "AGGREGATOR",
+                        "value": "$(vnf-ma/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "APP",
+                        "value": "test"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Content Consumer Emulator (CCE) To play HLS flows from Streaming engine",
+                    "id": "cce",
+                    "image": "ignaciodomin/media-cce:dev",
+                    "name": "cce",
+                    "parameters": [
+                      {
+                        "key": "STREAMMING_ENGINE",
+                        "value": "$(vnf-mse/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "exercise",
+            "steps": [
+              {
+                "command": "/bin/sh",
+                "description": "Starting the CPE that simulates the camera",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 1,
+                "instances": 1,
+                "name": "cpe",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "cpe"
+              },
+              {
+                "description": "Starting the CCE that simulates the consumer",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 2,
+                "instances": 1,
+                "name": "ffprobe",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "ffprobe",
+                "start_delay": 5
+              },
+              {
+                "description": "Starting the CCE that simulates the consumer",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 3,
+                "instances": 1,
+                "name": "cce",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "cce",
+                "start_delay": 20
+              },
+              {
+                "dependencies": [
+                  "cpe",
+                  "ffprobe",
+                  "cce"
+                ],
+                "description": "Starting the CCE that simulates the consumer",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 4,
+                "instances": 1,
+                "name": "parser",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "ffprobe"
+              }
+            ]
+          },
+          {
+            "id": "verification",
+            "steps": [
+              {
+                "conditions": [
+                  {
+                    "condition": "not present",
+                    "file": "status.txt",
+                    "find": "ERROR",
+                    "name": "status",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check cpe",
+                "name": "cpe",
+                "step": "cpe"
+              },
+              {
+                "conditions": [
+                  {
+                    "condition": "not present",
+                    "file": "status.txt",
+                    "find": "ERROR",
+                    "name": "status",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check cce",
+                "name": "cce",
+                "step": "cce"
+              },
+              {
+                "conditions": [
+                  {
+                    "condition": "not present",
+                    "file": "status.txt",
+                    "find": "ERROR",
+                    "name": "status",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check ffprobe",
+                "name": "ffprobe",
+                "step": "ffprobe"
+              },
+              {
+                "conditions": [
+                  {
+                    "condition": "<",
+                    "file": "detail.json",
+                    "find": "error_rate",
+                    "name": "error_rate",
+                    "type": "json",
+                    "value": "0.05",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check obtained results",
+                "name": "parser",
+                "step": "parser"
+              }
+            ]
+          }
+        ],
+        "service_platforms": [
+          "SONATA"
+        ],
+        "test_category": [
+          "benchmarking"
+        ],
+        "test_tags": [
+          "streamingPerformance"
+        ],
+        "vendor": "eu.5gtango.atos",
+        "version": "0.1"
+      },
+      "uuid": "17898765567"
     }
   ]
 }


### PR DESCRIPTION
- change back to test H2 db
- allow testResults empty value in  Curator's callback requests for error or possible cancelling reasons 
- logging with format "#vnvlogPlanner.<className>.<methodName>"
