### PR TITLE
Resolving 404 to Planner callback

### DIFF
--- a/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
@@ -147,8 +147,8 @@ class TestPlanRequest {
     def testd
     Boolean lastTest = false
     List<TestPlanCallback> testPlanCallbacks = [
-            new TestPlanCallback(eventActor: 'Curator', url: '/api/v1/test-plans/on-change/completed/', status:'COMPLETED'),
-            new TestPlanCallback(eventActor: 'Curator', url: '/api/v1/test-plans/on-change/'),
+            new TestPlanCallback(eventActor: 'Curator', url: '/tng-vnv-planner/api/v1/test-plans/on-change/completed/', status:'COMPLETED'),
+            new TestPlanCallback(eventActor: 'Curator', url: '/tng-vnv-planner/api/v1/test-plans/on-change/'),
     ]
 }
 

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
@@ -187,4 +187,5 @@ class TestPlanControllerTest extends TestRestSpec {
         testPlanService.save(testPlan)
     }
 
+
 }


### PR DESCRIPTION
workaround for the request of Curator to Planner's callback -
 https://github.com/sonata-nfv/tng-vnv-planner/issues/73