### PR TITLE
Resolving 404 and 500 from Planner callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ docker run -d --name tng-vnv-planner -p 6100:6100 registry.sonata-nfv.eu:5000/tn
 
 Once the component finish start, you can access (change IP depends on your docker setup) the component health endpoint at:
 
-http://locahost:6100/tng-vnv-planner/health
+http://locahost:6100/health
 
 ### Swagger UI
 
 * static
-    * http://petstore.swagger.io/?url=https://raw.githubusercontent.com/sonata-nfv/tng-vnv-planner/master/src/main/resources/static/swagger.json
-    * http://petstore.swagger.io/?url=https://raw.githubusercontent.com/sonata-nfv/tng-vnv-planner/master/src/main/resources/static/swagger-dependencies.json
+    * http://petstore.swagger.io/?url=https://raw.githubusercontent.com/sonata-nfv/master/src/main/resources/static/swagger.json
+    * http://petstore.swagger.io/?url=https://raw.githubusercontent.com/sonata-nfv/master/src/main/resources/static/swagger-dependencies.json
 * pre integration 
-    * http://pre-int-vnv-ave.5gtango.eu:6100/tng-vnv-planner/swagger-ui.html
+    * http://pre-int-vnv-ave.5gtango.eu:6100/swagger-ui.html
 * local 
-    * http://localhost:6100/tng-vnv-planner/swagger-ui.html
-    * http://localhost:6100/tng-vnv-planner/swagger-ui.html?urls.primaryName=dependencies
+    * http://localhost:6100/swagger-ui.html
+    * http://localhost:6100/swagger-ui.html?urls.primaryName=dependencies
 
 
 

--- a/src/main/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackController.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackController.groovy
@@ -65,9 +65,9 @@ class CuratorCallbackController {
     @PostMapping('/on-change/completed')
     @ResponseBody
     void onChangeCompleted(@Valid @RequestBody TestPlanCallback callback) {
-        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChangeCompleted: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} STR [CallbackBody.status: ${callback.status}]")
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChangeCompleted: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} STR [CallbackBody.status: ${callback?.status}]")
         testPlanService.update(callback.testPlanUuid, callback.status)
-        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChangeCompleted: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} END [CallbackBody.status: ${callback.status}]")
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChangeCompleted: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} END [CallbackBody.status: ${callback?.status}]")
     }
 
     @ApiResponses(value = [
@@ -77,9 +77,9 @@ class CuratorCallbackController {
     @PostMapping('/on-change/')
     @ResponseBody
     void onChange(@Valid @RequestBody TestPlanCallback callback) {
-        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChange: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} STR [CallbackBody.status: ${callback.status}]")
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChange: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} STR [CallbackBody.status: ${callback?.status}]")
         testPlanService.update(callback.testPlanUuid, callback.status)
-        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChange: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} END [CallbackBody.status: ${callback.status}]")
+        log.info("#~#vnvlogPlanner.CuratorCallbackController.onChange: testPlan.uuid: ${callback?.testPlanUuid}, status: ${callback?.status} END [CallbackBody.status: ${callback?.status}]")
     }
 }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
@@ -147,8 +147,8 @@ class TestPlanRequest {
     def testd
     Boolean lastTest = false
     List<TestPlanCallback> testPlanCallbacks = [
-            new TestPlanCallback(eventActor: 'Curator', url: '/tng-vnv-planner/api/v1/test-plans/on-change/completed/', status:'COMPLETED'),
-            new TestPlanCallback(eventActor: 'Curator', url: '/tng-vnv-planner/api/v1/test-plans/on-change/'),
+            new TestPlanCallback(eventActor: 'Curator', url: '/api/v1/test-plans/on-change/completed/', status:'COMPLETED'),
+            new TestPlanCallback(eventActor: 'Curator', url: '/api/v1/test-plans/on-change/'),
     ]
 }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/model/TestPlan.groovy
@@ -147,8 +147,8 @@ class TestPlanRequest {
     def testd
     Boolean lastTest = false
     List<TestPlanCallback> testPlanCallbacks = [
-            new TestPlanCallback(eventActor: 'Curator', url: '/api/v1/test-plans/on-change/completed/', status:'COMPLETED'),
-            new TestPlanCallback(eventActor: 'Curator', url: '/api/v1/test-plans/on-change/'),
+            new TestPlanCallback(eventActor: 'Curator', url: '/tng-vnv-planner/api/v1/test-plans/on-change/completed/', status:'COMPLETED'),
+            new TestPlanCallback(eventActor: 'Curator', url: '/tng-vnv-planner/api/v1/test-plans/on-change/'),
     ]
 }
 

--- a/src/main/groovy/com/github/tng/vnv/planner/repository/TestPlanRepository.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/repository/TestPlanRepository.groovy
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface TestPlanRepository extends JpaRepository<TestPlan, Long> {
     TestPlan findFirstByStatus(String status)
-    TestPlan findLastByUuid(String uuid)
+    TestPlan findFirstByUuidOrderByIdDesc(String uuid)
     List<TestPlan> findByTestSuite(TestSuite t)
     List<TestPlan> findAll()
 }

--- a/src/main/groovy/com/github/tng/vnv/planner/service/TestPlanService.groovy
+++ b/src/main/groovy/com/github/tng/vnv/planner/service/TestPlanService.groovy
@@ -38,15 +38,12 @@ import com.github.tng.vnv.planner.model.NetworkService
 import com.github.tng.vnv.planner.model.Package
 import com.github.tng.vnv.planner.model.Test
 import com.github.tng.vnv.planner.repository.TestPlanRepository
-import com.github.tng.vnv.planner.model.NetworkServiceDescriptor
 import com.github.tng.vnv.planner.model.TestPlan
 import com.github.tng.vnv.planner.repository.TestSuiteRepository
 import com.github.tng.vnv.planner.utils.TEST_PLAN_STATUS
 import groovy.util.logging.Log
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-
-import static com.github.tng.vnv.planner.utils.TEST_PLAN_STATUS.DELETED
 
 @Log
 @Service
@@ -133,7 +130,7 @@ class TestPlanService {
     }
 
     TestPlan findByUuid(String uuid){
-        testPlanRepository.findLastByUuid(uuid)
+        testPlanRepository.findFirstByUuidOrderByIdDesc(uuid)
     }
     TestPlan findNextScheduledTestPlan() {
         testPlanRepository.findFirstByStatus(TEST_PLAN_STATUS.SCHEDULED)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,6 @@
 
 server:
   port: 6100
-  contextPath: /tng-vnv-planner
 api:
   name: tng-vnv-planner
   description: An H2020 5GTANGO project

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,12 +64,6 @@ app:
     host: tng-cat
     base.url: http://${app.cat.host}:4011/api/catalogues/v2
 
-  tpr:
-    host: tng-rep
-    base.url: http://${app.tpr.host}:4012/trr
-    test.plan.create.endpoint: ${app.tpr.base.url}/test-plans
-    test.plan.update.endpoint: ${app.tpr.base.url}/test-plans/{uuid}
-
   curator:
     host: tng-vnv-curator
     base.url: http://${app.curator.host}:6200/api/v1

--- a/src/main/resources/static/swagger-dependencies.json
+++ b/src/main/resources/static/swagger-dependencies.json
@@ -11,7 +11,7 @@
         }
     },
     "host": "tng-vnv-planner:6100",
-    "basePath": "/tng-vnv-planner",
+    "basePath": "/",
     "tags": [
         {
             "name": "catalogue-mock",

--- a/src/main/resources/static/swagger.json
+++ b/src/main/resources/static/swagger.json
@@ -11,7 +11,7 @@
         }
     },
     "host": "tng-vnv-planner:6100",
-    "basePath": "/tng-vnv-planner",
+    "basePath": "/",
     "tags": [
         {
             "name": "catalogue-callback-controller",

--- a/src/test/groovy/com/github/tng/vnv/planner/WorkFlowManagerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/WorkFlowManagerTest.groovy
@@ -62,7 +62,7 @@ class WorkFlowManagerTest extends TestRestSpec {
         scheduleTestPlan(TEST_PLAN_UUID_4, TEST_PLAN_STATUS.SCHEDULED, '2nd scheduled testPlan')
         and:
         Thread.sleep(1500L);
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans/on-change/completed',
+        def entity = postForEntity('/api/v1/test-plans/on-change/completed',
                 [
                         event_actor: 'tng-vnv-curator',
                         status: 'COMPLETED',

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/CatalogueCallbackControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/CatalogueCallbackControllerTest.groovy
@@ -53,7 +53,7 @@ class CatalogueCallbackControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        def entity = postForEntity('/tng-vnv-planner/api/v1/packages/on-change',
+        def entity = postForEntity('/api/v1/packages/on-change',
                 [
                         event_name: UUID.randomUUID().toString(),
                         package_id:  MULTIPLE_TEST_PLANS_PACKAGE_ID,

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackControllerTest.groovy
@@ -49,6 +49,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
     public static final String TEST_RESULT_UUID = UUID.randomUUID().toString()
     public static final String TEST_RESULT2_UUID = UUID.randomUUID().toString()
     public static final String TEST_PLAN_UUID = '109873678'
+    public static final String TEST_PLAN2_UUID = '561ba353-234c-44ba-9f17-f3e48caca4a5'
 
     @Autowired
     TestPlanService testPlanService
@@ -60,7 +61,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        createDummyTestPlan()
+        createDummyTestPlan(TEST_PLAN_UUID)
         def status = TEST_PLAN_STATUS.COMPLETED
         def entity = postForEntity('/api/v1/test-plans/on-change/completed',
                 [
@@ -92,7 +93,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        createDummyTestPlan()
+        createDummyTestPlan(TEST_PLAN_UUID)
         def status = TEST_PLAN_STATUS.CANCELLING
         def entity = postForEntity('/api/v1/test-plans/on-change/',
                 [
@@ -124,7 +125,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        createDummyTestPlan()
+        createDummyTestPlan(TEST_PLAN_UUID)
         def status = TEST_PLAN_STATUS.ERROR
         def entity = postForEntity('/api/v1/test-plans/on-change/',
                 [
@@ -141,8 +142,33 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         testPlanService.findByUuid(TEST_PLAN_UUID).status==status
     }
 
-    void createDummyTestPlan(){
-        def testPlan = new TestPlan(uuid: TEST_PLAN_UUID, status: 'dummyTestPlan')
+    void 'following an completed testPlan in Paris should store the testPlan as completed'() {
+        setup:
+        cleanTestPlanDB()
+        when:
+        createDummyTestPlan(TEST_PLAN2_UUID)
+        def entity = postForEntity('/api/v1/test-plans/on-change/completed',
+                [
+                        event_actor: 'Curator',
+                        status: 'COMPLETED',
+                        test_plan_uuid: TEST_PLAN2_UUID,
+                        test_results: [
+                                [
+                                    test_uuid: '639ce960-5a76-4722-9d5c-ee7c476ece10',
+                                    test_results_uuid: '1af9de2d-15c0-4dee-a8b1-6801e4e38bec',
+                                    test_status: 'COMPLETED'
+                                ]
+
+                        ],
+                ]
+                , Void.class)
+        then:
+        entity.statusCode == HttpStatus.OK
+        testPlanService.findByUuid(TEST_PLAN2_UUID).status=='COMPLETED'
+    }
+
+    void createDummyTestPlan(String test_plan_uuid){
+        def testPlan = new TestPlan(uuid: test_plan_uuid, status: 'dummyTestPlan')
         def testSuite = new TestSuite()
         testSuite = testSuiteService.save(testSuite)
         testPlan.testSuite = testSuite

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/CuratorCallbackControllerTest.groovy
@@ -62,7 +62,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         when:
         createDummyTestPlan()
         def status = TEST_PLAN_STATUS.COMPLETED
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans/on-change/completed',
+        def entity = postForEntity('/api/v1/test-plans/on-change/completed',
                 [
                         event_actor: 'tng-vnv-curator',
                         status: status,
@@ -94,7 +94,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         when:
         createDummyTestPlan()
         def status = TEST_PLAN_STATUS.CANCELLING
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans/on-change/',
+        def entity = postForEntity('/api/v1/test-plans/on-change/',
                 [
                         event_actor: 'tng-vnv-curator',
                         status:status,
@@ -126,7 +126,7 @@ class CuratorCallbackControllerTest extends TestRestSpec {
         when:
         createDummyTestPlan()
         def status = TEST_PLAN_STATUS.ERROR
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans/on-change/',
+        def entity = postForEntity('/api/v1/test-plans/on-change/',
                 [
                         event_actor: 'tng-vnv-curator',
                         status:status,

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/NetworkServiceControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/NetworkServiceControllerTest.groovy
@@ -38,6 +38,7 @@ package com.github.tng.vnv.planner.controller
 import com.github.tng.vnv.planner.config.TestRestSpec
 import com.github.tng.vnv.planner.restmock.CatalogueMock
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 
 class NetworkServiceControllerTest extends TestRestSpec {
 
@@ -48,8 +49,9 @@ class NetworkServiceControllerTest extends TestRestSpec {
 
     void "retrieval of a single test suite's related tests should successfully all the tag related tests"() {
         when:
-        List tss = getForEntity('/tng-vnv-planner/api/v1/test-plans/services/{serviceUuid}/tests', List, NETWORK_SERVICE_ID).body
+        def entity = getForEntity('/api/v1/test-plans/services/{serviceUuid}/tests', List, NETWORK_SERVICE_ID)
         then:
-        tss.size() == 4
+        entity.statusCode == HttpStatus.OK
+        entity.body.size() == 4
     }
 }

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
@@ -41,7 +41,7 @@ class TestPlanControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans',
+        def entity = postForEntity('/api/v1/test-plans',
                 [
                         'test_plans':
                                 [
@@ -84,7 +84,7 @@ class TestPlanControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans',
+        def entity = postForEntity('/api/v1/test-plans',
                 [
                         'test_plans':
                                 [
@@ -124,7 +124,7 @@ class TestPlanControllerTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans',
+        def entity = postForEntity('/api/v1/test-plans',
                 [
                         'test_plans':
                                 [
@@ -150,7 +150,7 @@ class TestPlanControllerTest extends TestRestSpec {
         cleanTestPlanDB()
         when:
         scheduleTestPlan(TEST_PLAN_UUID, TEST_PLAN_STATUS.CREATED, 'scheduled testPlan\'s status which will turn into canceling')
-        delete('/tng-vnv-planner/api/v1/test-plans/{uuid}',TEST_PLAN_UUID)
+        delete('/api/v1/test-plans/{uuid}',TEST_PLAN_UUID)
         then:
         testPlanService.testPlanRepository.findAll().find {it.uuid == TEST_PLAN_UUID}.status == TEST_PLAN_STATUS.CANCELLING
     }
@@ -161,21 +161,23 @@ class TestPlanControllerTest extends TestRestSpec {
         cleanTestPlanDB()
         when:
         def testPlan = scheduleTestPlan(TEST_PLAN_UUID, TEST_PLAN_STATUS.CREATED, 'scheduled testPlan\'s status which will be listed for a specific testPlanListUuid')
+        def entity = getForEntity('/api/v1/test-plans/{testPlanListUuid}', TestPlan[], testPlan.testSuite.uuid)
         then:
-        getForEntity('/tng-vnv-planner/api/v1/test-plans/{testPlanListUuid}', TestPlan[], testPlan.testSuite.uuid).body.size() == 1
+        entity.statusCode == HttpStatus.OK
+        entity.body.size() == 1
     }
 
     @Ignore
     void "list all test plans request should successfully return the list of all test plans"() {
 
         setup:
-        cleanTestPlansRepo()
+        cleanTestPlanDB()
         when:
         scheduleTestPlan(TEST_PLAN_UUID, "TEST_LIST_ALL_STATUS", '')
         scheduleTestPlan(TEST_PLAN_UUID2, "TEST_LIST_ALL_STATUS", '')
         then:
-        def testPlans = getForEntity('/tng-vnv-planner/api/v1/test-plans/', TestPlan[]).body
-                testPlans.collect {it.status == "TEST_LIST_ALL_STATUS"}.size()==2
+        def testPlans = getForEntity('/api/v1/test-plans/', TestPlan[]).body
+        testPlans.collect {it.status == "TEST_LIST_ALL_STATUS"}.size()==2
     }
 
     TestPlan scheduleTestPlan(String uuid, String status, String description){

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
@@ -152,7 +152,7 @@ class TestPlanControllerTest extends TestRestSpec {
         scheduleTestPlan(TEST_PLAN_UUID, TEST_PLAN_STATUS.CREATED, 'scheduled testPlan\'s status which will turn into canceling')
         delete('/api/v1/test-plans/{uuid}',TEST_PLAN_UUID)
         then:
-        testPlanService.testPlanRepository.findAll().find {it.uuid == TEST_PLAN_UUID}.status == TEST_PLAN_STATUS.CANCELLING
+        testPlanService.testPlanRepository.findAll().findAll {it.uuid == TEST_PLAN_UUID}.last().status == TEST_PLAN_STATUS.CANCELLING
     }
 
     void "list test plans request for one testPlan list uuid test plan should successfully return the list of corresponding test plans"() {

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
@@ -167,17 +167,15 @@ class TestPlanControllerTest extends TestRestSpec {
         entity.body.size() == 1
     }
 
-    @Ignore
     void "list all test plans request should successfully return the list of all test plans"() {
 
         setup:
         cleanTestPlanDB()
         when:
         scheduleTestPlan(TEST_PLAN_UUID, "TEST_LIST_ALL_STATUS", '')
-        scheduleTestPlan(TEST_PLAN_UUID2, "TEST_LIST_ALL_STATUS", '')
         then:
         def testPlans = getForEntity('/api/v1/test-plans/', TestPlan[]).body
-        testPlans.collect {it.status == "TEST_LIST_ALL_STATUS"}.size()==2
+        testPlans.size()>=1
     }
 
     TestPlan scheduleTestPlan(String uuid, String status, String description){

--- a/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/controller/TestPlanControllerTest.groovy
@@ -187,4 +187,5 @@ class TestPlanControllerTest extends TestRestSpec {
         testPlanService.save(testPlan)
     }
 
+
 }

--- a/src/test/groovy/com/github/tng/vnv/planner/service/TestPlanServiceTest.groovy
+++ b/src/test/groovy/com/github/tng/vnv/planner/service/TestPlanServiceTest.groovy
@@ -12,7 +12,7 @@ class TestPlanServiceTest extends TestRestSpec {
         setup:
         cleanTestPlanDB()
         when:
-        def entity = postForEntity('/tng-vnv-planner/api/v1/test-plans',
+        def entity = postForEntity('/api/v1/test-plans',
                 [
                         uuid: UUID.randomUUID(),
                         test_plans:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,11 +32,11 @@
 
 
 app:
-  gk.base.url: http://localhost:${server.port}/tng-vnv-planner/mock/gk
-  vnvgk.base.url: http://localhost:${server.port}/tng-vnv-planner/mock/gk
-  cat.base.url: http://localhost:${server.port}/tng-vnv-planner/mock/catalogue
-  tpr.base.url: http://localhost:${server.port}/tng-vnv-planner/mock/tpr
-  curator.base.url: http://localhost:${server.port}/tng-vnv-planner/mock/curator
+  gk.base.url: http://localhost:${server.port}/mock/gk
+  vnvgk.base.url: http://localhost:${server.port}/mock/gk
+  cat.base.url: http://localhost:${server.port}/mock/catalogue
+  tpr.base.url: http://localhost:${server.port}/mock/tpr
+  curator.base.url: http://localhost:${server.port}/mock/curator
   test.package.id: myNS:UPB:1.0
 
 spring.profiles.active: test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,7 +35,6 @@ app:
   gk.base.url: http://localhost:${server.port}/mock/gk
   vnvgk.base.url: http://localhost:${server.port}/mock/gk
   cat.base.url: http://localhost:${server.port}/mock/catalogue
-  tpr.base.url: http://localhost:${server.port}/mock/tpr
   curator.base.url: http://localhost:${server.port}/mock/curator
   test.package.id: myNS:UPB:1.0
 

--- a/src/test/resources/static/json/testPlanRequestThroughPlanner.json
+++ b/src/test/resources/static/json/testPlanRequestThroughPlanner.json
@@ -1,0 +1,306 @@
+{
+  "id": 100,
+  "test_plans": [
+    {
+      "description": "Test Plan Description: Adhoc TD,NSD request for testing at 10:50utc  before brexit",
+      "id": 7,
+      "index": 3,
+      "nsd": {
+        "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/service-descriptor/nsd-schema.yml",
+        "vendor": "eu.sonata-nfv",
+        "name": "mediapilot-service",
+        "version": "0.2",
+        "author": "Ignacio Dominguez @: atos",
+        "description": "This NS provides the video streaming service for the immersive media pilot.",
+        "network_functions": [
+          {
+            "vnf_id": "vnf-ma",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-ma",
+            "vnf_version": "0.2"
+          },
+          {
+            "vnf_id": "vnf-mse",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-mse",
+            "vnf_version": "0.2"
+          },
+          {
+            "vnf_id": "vnf-cms",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-cms",
+            "vnf_version": "0.1"
+          }
+        ],
+        "connection_points": [
+          {
+            "id": "nscpexternal",
+            "interface": "ipv4",
+            "type": "external"
+          }
+        ],
+        "testing_tags": [
+          "http"
+        ],
+        "virtual_links": [
+          {
+            "id": "vlexternal",
+            "connectivity_type": "E-LAN",
+            "connection_points_reference": [
+              "vnf-ma:rtmp",
+              "vnf-mse:hls",
+              "vnf-cms:api",
+              "nscpexternal"
+            ]
+          },
+          {
+            "id": "cms-aggregator",
+            "connectivity_type": "E-Line",
+            "connection_points_reference": [
+              "vnf-cms:api",
+              "vnf-ma:api"
+            ]
+          },
+          {
+            "id": "aggregator-mse",
+            "connectivity_type": "E-Line",
+            "connection_points_reference": [
+              "vnf-ma:rtmp",
+              "vnf-mse:rtmp"
+            ]
+          }
+        ]
+      },
+      "status": "string",
+      "testd": {
+        "author": "Ignacio Dominguez, Felipe Vicens (ATOS)",
+        "description": "Performance test for video analysis ",
+        "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/test-descriptor/testdescriptor-schema.yml",
+        "name": "test-immersive-media",
+        "vendor": "eu.5gtango.atos",
+        "version": "0.1",
+        "phases": [
+          {
+            "id": "setup",
+            "steps": [
+              {
+                "action": "deploy",
+                "description": "Deploying a NS",
+                "name": "deployment"
+              },
+              {
+                "action": "configure",
+                "description": null,
+                "name": "configuration",
+                "probes": [
+                  {
+                    "description": "A service initial configuration container",
+                    "id": "initiator",
+                    "image": "ignaciodomin/media-initiator:dev",
+                    "name": "initiator",
+                    "parameters": [
+                      {
+                        "key": "CAMERA",
+                        "value": "test"
+                      },
+                      {
+                        "key": "CMS",
+                        "value": "\$(vnf-cms/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "MA",
+                        "value": "\$(vnf-ma/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "MSE",
+                        "value": "\$(vnf-mse/endpoints/id:floating_ip/address)"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ffprobe",
+                    "name": "ffprobe",
+                    "image": "ignaciodomin/media-ffprobe:dev",
+                    "description": "Ffprobe",
+                    "parameters": [
+                      {
+                        "key": "STREAMING_ENGINE",
+                        "value": "\$(vnf-mse/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "parser",
+                    "name": "parser",
+                    "image": "ignaciodomin/media-parser:dev",
+                    "description": "Parser",
+                    "parameters": []
+                  },
+                  {
+                    "description": "Content Producer Emulator (CPE) To generate a RTMP flow",
+                    "id": "cpe",
+                    "image": "ignaciodomin/media-cpe:plane",
+                    "name": "cpe",
+                    "parameters": [
+                      {
+                        "key": "AGGREGATOR",
+                        "value": "\$(vnf-ma/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "APP",
+                        "value": "test"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Content Consumer Emulator (CCE) To play HLS flows from Streaming engine",
+                    "id": "cce",
+                    "image": "ignaciodomin/media-cce:dev",
+                    "name": "cce",
+                    "parameters": [
+                      {
+                        "key": "STREAMING_ENGINE",
+                        "value": "\$(vnf-mse/endpoints/id:floating_ip/address)"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "exercise",
+            "steps": [
+              {
+                "name": "initiator",
+                "description": "Starting the initiator",
+                "run": "initiator",
+                "index": 1,
+                "entrypoint": "/app/entrypoint.sh",
+                "command": "/bin/sh",
+                "instances": 1,
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "dependencies": []
+              },
+              {
+                "name": "cpe",
+                "description": "Starting the CPE that simulates the camera",
+                "run": "cpe",
+                "index": 1,
+                "start_delay": 5,
+                "entrypoint": "/app/entrypoint.sh",
+                "command": "/bin/sh",
+                "instances": 1,
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ]
+              },
+              {
+                "name": "ffprobe",
+                "description": "Starting the CCE that simulates the consumer",
+                "run": "ffprobe",
+                "index": 2,
+                "entrypoint": "/app/entrypoint.sh",
+                "start_delay": 10,
+                "instances": 1,
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "dependencies": [
+                  "initiator"
+                ]
+              },
+              {
+                "name": "cce",
+                "description": "Starting the CCE that simulates the consumer",
+                "run": "cce",
+                "index": 3,
+                "entrypoint": "/app/entrypoint.sh",
+                "start_delay": 25,
+                "instances": 1,
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "dependencies": [
+                  "initiator"
+                ]
+              },
+              {
+                "name": "parser",
+                "description": "Starting the CCE that simulates the consumer",
+                "run": "parser",
+                "index": 4,
+                "entrypoint": "/app/entrypoint.sh",
+                "instances": 1,
+                "output": [
+                  {
+                    "results": "result.json"
+                  }
+                ],
+                "dependencies": [
+                  "initiator",
+                  "cpe",
+                  "ffprobe",
+                  "cce"
+                ]
+              }
+            ]
+          },
+          {
+            "id": "verification",
+            "steps": [
+              {
+                "name": "parser",
+                "description": "Check obtained results",
+                "step": "parser",
+                "conditions": [
+                  {
+                    "name": "lost-frames",
+                    "file": "result.json",
+                    "type": "json",
+                    "find": "lost-frames",
+                    "condition": "<",
+                    "value": "90",
+                    "verdict": "pass"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "service_platforms": [
+          "SONATA"
+        ],
+        "test_category": [
+          "benchmarking"
+        ],
+        "test_tags": [
+          "rtmp-media-service"
+        ]
+      }
+    }
+  ],
+  "uuid": "45678987654"
+}

--- a/src/test/resources/static/json/testPlanThroughCurator.json
+++ b/src/test/resources/static/json/testPlanThroughCurator.json
@@ -1,0 +1,325 @@
+{
+  "nsd": {
+    "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/service-descriptor/nsd-schema.yml",
+    "vendor": "eu.sonata-nfv",
+    "name": "mediapilot-service",
+    "version": "0.2",
+    "author": "Ignacio Dominguez @: atos",
+    "description": "This NS provides the video streaming service for the immersive media pilot.",
+    "network_functions": [
+      {
+        "vnf_id": "vnf-ma",
+        "vnf_vendor": "eu.5gtango",
+        "vnf_name": "vnf-ma",
+        "vnf_version": "0.2"
+      },
+      {
+        "vnf_id": "vnf-mse",
+        "vnf_vendor": "eu.5gtango",
+        "vnf_name": "vnf-mse",
+        "vnf_version": "0.2"
+      },
+      {
+        "vnf_id": "vnf-cms",
+        "vnf_vendor": "eu.5gtango",
+        "vnf_name": "vnf-cms",
+        "vnf_version": "0.1"
+      }
+    ],
+    "connection_points": [
+      {
+        "id": "nscpexternal",
+        "interface": "ipv4",
+        "type": "external"
+      }
+    ],
+    "testing_tags": [
+      "http"
+    ],
+    "virtual_links": [
+      {
+        "id": "vlexternal",
+        "connectivity_type": "E-LAN",
+        "connection_points_reference": [
+          "vnf-ma:rtmp",
+          "vnf-mse:hls",
+          "vnf-cms:api",
+          "nscpexternal"
+        ]
+      },
+      {
+        "id": "cms-aggregator",
+        "connectivity_type": "E-Line",
+        "connection_points_reference": [
+          "vnf-cms:api",
+          "vnf-ma:api"
+        ]
+      },
+      {
+        "id": "aggregator-mse",
+        "connectivity_type": "E-Line",
+        "connection_points_reference": [
+          "vnf-ma:rtmp",
+          "vnf-mse:rtmp"
+        ]
+      }
+    ]
+  },
+  "test_plan_callbacks":[
+    {
+      "event_actor":"Curator",
+      "url":"/test-plans/on-change/completed",
+      "status":"COMPLETED",
+      "test_plan_uuid":null,
+      "test_results":[
+        {
+          "test_uuid": null,
+          "test_result_uuid": null,
+          "test_status": null
+        }
+      ]
+    },
+    {
+      "event_actor":"Curator",
+      "url":"/test-plans/on-change",
+      "status":"COMPLETED",
+      "test_plan_uuid":null,
+      "test_results":[
+        {
+          "test_uuid": null,
+          "test_result_uuid": null,
+          "test_status": null
+        }
+      ]
+    }
+  ],
+  "testd": {
+    "author": "Ignacio Dominguez, Felipe Vicens (ATOS)",
+    "description": "Performance test for video analysis",
+    "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/test-descriptor/testdescriptor-schema.yml",
+    "name": "test-immersive-media",
+    "vendor": "eu.5gtango.atos",
+    "version": "0.1",
+    "phases": [
+      {
+        "id": "setup",
+        "steps": [
+          {
+            "action": "deploy",
+            "description": "Deploying a NS",
+            "name": "deployment"
+          },
+          {
+            "action": "configure",
+            "description": null,
+            "name": "configuration",
+            "probes": [
+              {
+                "description": "A service initial configuration container",
+                "id": "initiator",
+                "image": "ignaciodomin/media-initiator:dev",
+                "name": "initiator",
+                "parameters": [
+                  {
+                    "key": "CAMERA",
+                    "value": "test"
+                  },
+                  {
+                    "key": "CMS",
+                    "value": "\$(vnf-cms/endpoints/id:floating_ip/address)"
+                  },
+                  {
+                    "key": "MA",
+                    "value": "\$(vnf-ma/endpoints/id:floating_ip/address)"
+                  },
+                  {
+                    "key": "MSE",
+                    "value": "\$(vnf-mse/endpoints/id:floating_ip/address)"
+                  }
+                ]
+              },
+              {
+                "id": "ffprobe",
+                "name": "ffprobe",
+                "image": "ignaciodomin/media-ffprobe:dev",
+                "description": "Ffprobe",
+                "parameters": [
+                  {
+                    "key": "STREAMING_ENGINE",
+                    "value": "\$(vnf-mse/endpoints/id:floating_ip/address)"
+                  },
+                  {
+                    "key": "STREAM",
+                    "value": "test"
+                  }
+                ]
+              },
+              {
+                "id": "parser",
+                "name": "parser",
+                "image": "ignaciodomin/media-parser:dev",
+                "description": "Parser",
+                "parameters": []
+              },
+              {
+                "description": "Content Producer Emulator (CPE) To generate a RTMP flow",
+                "id": "cpe",
+                "image": "ignaciodomin/media-cpe:plane",
+                "name": "cpe",
+                "parameters": [
+                  {
+                    "key": "AGGREGATOR",
+                    "value": "\$(vnf-ma/endpoints/id:floating_ip/address)"
+                  },
+                  {
+                    "key": "APP",
+                    "value": "test"
+                  },
+                  {
+                    "key": "STREAM",
+                    "value": "test"
+                  }
+                ]
+              },
+              {
+                "description": "Content Consumer Emulator (CCE) To play HLS flows from Streaming engine",
+                "id": "cce",
+                "image": "ignaciodomin/media-cce:dev",
+                "name": "cce",
+                "parameters": [
+                  {
+                    "key": "STREAMING_ENGINE",
+                    "value": "\$(vnf-mse/endpoints/id:floating_ip/address)"
+                  },
+                  {
+                    "key": "STREAM",
+                    "value": "test"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "exercise",
+        "steps": [
+          {
+            "name": "initiator",
+            "description": "Starting the initiator",
+            "run": "initiator",
+            "index": 1,
+            "entrypoint": "/app/entrypoint.sh",
+            "command": "/bin/sh",
+            "instances": 1,
+            "output": [
+              {
+                "results": "logs.txt"
+              }
+            ],
+            "dependencies": []
+          },
+          {
+            "name": "cpe",
+            "description": "Starting the CPE that simulates the camera",
+            "run": "cpe",
+            "index": 1,
+            "start_delay": 5,
+            "entrypoint": "/app/entrypoint.sh",
+            "command": "/bin/sh",
+            "instances": 1,
+            "output": [
+              {
+                "results": "logs.txt"
+              }
+            ]
+          },
+          {
+            "name": "ffprobe",
+            "description": "Starting the CCE that simulates the consumer",
+            "run": "ffprobe",
+            "index": 2,
+            "entrypoint": "/app/entrypoint.sh",
+            "start_delay": 10,
+            "instances": 1,
+            "output": [
+              {
+                "results": "logs.txt"
+              }
+            ],
+            "dependencies": [
+              "initiator"
+            ]
+          },
+          {
+            "name": "cce",
+            "description": "Starting the CCE that simulates the consumer",
+            "run": "cce",
+            "index": 3,
+            "entrypoint": "/app/entrypoint.sh",
+            "start_delay": 25,
+            "instances": 1,
+            "output": [
+              {
+                "results": "logs.txt"
+              }
+            ],
+            "dependencies": [
+              "initiator"
+            ]
+          },
+          {
+            "name": "parser",
+            "description": "Starting the CCE that simulates the consumer",
+            "run": "parser",
+            "index": 4,
+            "entrypoint": "/app/entrypoint.sh",
+            "instances": 1,
+            "output": [
+              {
+                "results": "result.json"
+              }
+            ],
+            "dependencies": [
+              "initiator",
+              "cpe",
+              "ffprobe",
+              "cce"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "verification",
+        "steps": [
+          {
+            "name": "parser",
+            "description": "Check obtained results",
+            "step": "parser",
+            "conditions": [
+              {
+                "name": "lost-frames",
+                "file": "result.json",
+                "type": "json",
+                "find": "lost-frames",
+                "condition": "<",
+                "value": "90",
+                "verdict": "pass"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "service_platforms": [
+      "SONATA"
+    ],
+    "test_category": [
+      "benchmarking"
+    ],
+    "test_tags": [
+      "rtmp-media-service"
+    ]
+  },
+  "last_test":false
+}


### PR DESCRIPTION
404: removing contextPath and clean project, 
500: retrieve the latest test plan uuid correctly avoiding null object result