### PR TITLE
Depending on the status of callback.status, the log that must be regi…

### DIFF
--- a/src/main/groovy/tng/vnv/planner/controller/TestPlanController.groovy
+++ b/src/main/groovy/tng/vnv/planner/controller/TestPlanController.groovy
@@ -201,10 +201,16 @@ class TestPlanController {
     @PostMapping('/on-change/completed')
     @ResponseBody
     void onChangeCompleted(@Valid @RequestBody CuratorCallback callback) {
-        tangoLoggerType = "I";
+        if(callback.status == 'ERROR'){
+          tangoLoggerType = "E";
+          tangoLoggerStatus = "500";
+        }
+        else{
+          tangoLoggerType = "I";
+          tangoLoggerStatus = "200";
+        }
         tangoLoggerOperation = "TestPlanController.onChangeCompleted";
         tangoLoggerMessage = ("/api/v1/test-plans/on-change/completed (test update notification received from curator. uuid=${callback.testPlanUuid} with status=${callback.status})");
-        tangoLoggerStatus = "200";
         tangoLogger.log(tangoLoggerType, tangoLoggerOperation, tangoLoggerMessage, tangoLoggerStatus)
 
         testService.updatePlanStatus(callback.testPlanUuid, callback.status)


### PR DESCRIPTION
Depending on the status of callback.status, the log that must be registered is of type information, I, or error, E.